### PR TITLE
Gestion mode token et mode id/mdp

### DIFF
--- a/core/class/tahomalocalapi.class.php
+++ b/core/class/tahomalocalapi.class.php
@@ -70,7 +70,7 @@ class tahomalocalapi extends eqLogic {
     } elseif ($token == '' and $user == '' and $pswd == '') {
         $return['launchable'] = 'nok';
         $return['launchable_message'] = __('Token ou couple identifiant/mot de passe obligatoire', __FILE__);
-    } elseif ($token == '' and $user == '' or $pswd == '') {
+    } elseif ($token == '' and ($user == '' or $pswd == '')) {
         if ($user == '') {
             $return['launchable'] = 'nok';
             $return['launchable_message'] = __('Le nom d\'utilisateur n\'est pas renseigné', __FILE__);

--- a/core/class/tahomalocalapi.class.php
+++ b/core/class/tahomalocalapi.class.php
@@ -73,10 +73,10 @@ class tahomalocalapi extends eqLogic {
     } elseif ($token == '' and $user == '' or $pswd == '') {
         if ($user == '') {
             $return['launchable'] = 'nok';
-            $return['launchable_message'] = __('Le nom d\'utilisateur n\'est pas configuré', __FILE__);
+            $return['launchable_message'] = __('Le nom d\'utilisateur n\'est pas renseigné', __FILE__);
         } elseif ($pswd == '') {
             $return['launchable'] = 'nok';
-            $return['launchable_message'] = __('Le mot de passe n\'est pas configuré', __FILE__);
+            $return['launchable_message'] = __('Le mot de passe n\'est pas renseigné', __FILE__);
         }
     }
     return $return;

--- a/core/class/tahomalocalapi.class.php
+++ b/core/class/tahomalocalapi.class.php
@@ -103,22 +103,27 @@ public static function deamon_start() {
   if ($deamon_info['launchable'] != 'ok') {
       throw new Exception(__('Veuillez vérifier la configuration', __FILE__));
   }
+  $token=config::byKey('tahomalocalapi_token', __CLASS__);
+  
   $request = '';
   $request .= ' --loglevel ' . log::convertLogLevel(log::getLogLevel(__CLASS__));
   $request .= ' --socketport ' . config::byKey('socketport', __CLASS__, '55009'); // port du daemon
   $request .= ' --callback ' . network::getNetworkAccess('internal', 'proto:127.0.0.1:port:comp') . '/plugins/tahomalocalapi/core/php/jeeTahomalocalapi.php'; // chemin de la callback url 
-  //$request .= ' --user "' . trim(str_replace('"', '\"', config::byKey('user', __CLASS__))) . '"'; // user compte somfy
-  //$request .= ' --pswd "' . trim(str_replace('"', '\"', config::byKey('password', __CLASS__))) . '"'; // et password compte Somfy
   $request .= ' --apikey ' . jeedom::getApiKey(__CLASS__); // l'apikey pour authentifier les échanges suivants
   $request .= ' --pid ' . jeedom::getTmpFolder(__CLASS__) . '/tahomalocalapid.pid'; // et on précise le chemin vers le pid file (ne pas modifier)
   $request .= ' --pincode "' . trim(str_replace('"', '\"', config::byKey('pincode', __CLASS__))) . '"'; // Pin code box Somfy
   $request .= ' --boxLocalIp "' . trim(str_replace('"', '\"', config::byKey('boxLocalIp', __CLASS__))) . '"'; // local IP box Somfy
   
-  //$tahomaSession=config::byKey('tahomalocalapi_session',  __CLASS__);
-  //if (is_array($tahomaSession) && array_key_exists('token', $tahomaSession)) {
-  	//$request .= ' --tahoma_token "' . trim(str_replace('"', '\"', $tokenTahoma['token'])) . '"'; // TahomaSession  
-  //}
-  $request .= ' --tahoma_token "' . trim(str_replace('"', '\"', config::byKey('tahomalocalapi_token', __CLASS__))) . '"';
+  if ($token == '') {
+      $request .= ' --user "' . trim(str_replace('"', '\"', config::byKey('user', __CLASS__))) . '"'; // user compte somfy
+      $request .= ' --pswd "' . trim(str_replace('"', '\"', config::byKey('password', __CLASS__))) . '"'; // et password compte Somfy
+      $tahomaSession=config::byKey('tahomalocalapi_session',  __CLASS__);
+      if (is_array($tahomaSession) && array_key_exists('token', $tahomaSession)) {
+        $request .= ' --tahoma_token "' . trim(str_replace('"', '\"', $tokenTahoma['token'])) . '"'; // TahomaSession  
+      }
+  } else {
+      $request .= ' --tahoma_token "' . trim(str_replace('"', '\"', config::byKey('tahomalocalapi_token', __CLASS__))) . '"';
+  }
   
   $tahomalocalapi_path = realpath(dirname(__FILE__) . '/../../resources/tahomalocalapid/');
   $pyenv_path = realpath(dirname(__FILE__) . '/../../resources/python_venv');

--- a/core/class/tahomalocalapi.class.php
+++ b/core/class/tahomalocalapi.class.php
@@ -58,21 +58,26 @@ class tahomalocalapi extends eqLogic {
     $user = config::byKey('user', __CLASS__); // exemple si votre démon à besoin de la config user,
     $pswd = config::byKey('password', __CLASS__); // password,
     $pinCode=config::byKey('pincode', __CLASS__);
+    $token=config::byKey('tahomalocalapi_token', __CLASS__);
     $tahomaBoxIp=config::byKey('boxLocalIp', __CLASS__);
-    // $clientId = config::byKey('clientId', __CLASS__); // et clientId
     $portDaemon=config::byKey('daemonPort', __CLASS__);
-    if ($user == '') {
+    if ($pinCode == '') {
         $return['launchable'] = 'nok';
-        $return['launchable_message'] = __('Le nom d\'utilisateur n\'est pas configuré', __FILE__);
-    } elseif ($pswd == '') {
-        $return['launchable'] = 'nok';
-        $return['launchable_message'] = __('Le mot de passe n\'est pas configuré', __FILE__);
-    } elseif ($pinCode == '') {
-        $return['launchable'] = 'nok';
-        $return['launchable_message'] = __('Le code pin de la box tahoma n\'est pas configuré', __FILE__);
+        $return['launchable_message'] = __('Le code pin de la box n\'est pas renseigné', __FILE__);
     } elseif ($tahomaBoxIp == '') {
         $return['launchable'] = 'nok';
-        $return['launchable_message'] = __('L\'adresse IP de la box tahoma n\'est pas configuré', __FILE__);
+        $return['launchable_message'] = __('L\'adresse IP de la box n\'est pas renseigné', __FILE__);
+    } elseif ($token == '' and $user == '' and $pswd == '') {
+        $return['launchable'] = 'nok';
+        $return['launchable_message'] = __('Token ou couple identifiant/mot de passe obligatoire', __FILE__);
+    } elseif ($token == '' and $user == '' or $pswd == '') {
+        if ($user == '') {
+            $return['launchable'] = 'nok';
+            $return['launchable_message'] = __('Le nom d\'utilisateur n\'est pas configuré', __FILE__);
+        } elseif ($pswd == '') {
+            $return['launchable'] = 'nok';
+            $return['launchable_message'] = __('Le mot de passe n\'est pas configuré', __FILE__);
+        }
     }
     return $return;
 }

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -26,16 +26,14 @@ if (!isConnect()) {
   <fieldset>
   	<legend><i class="fas fa-list-alt"></i> {{Configuration connexion compte Somfy}}</legend>
     <div class="form-group">
-      <label class="col-md-4 control-label">{{Nom utilisateur compte Somfy}}
-        <sup><i class="fas fa-question-circle tooltips" title="{{Nom utilisateur Somfy}}"></i></sup>
+      <label class="col-md-4 control-label">{{Nom d'utilisateur du compte Somfy}}
       </label>
       <div class="col-md-4">
         <input class="configKey form-control" data-l1key="user"/>
       </div>
     </div>
     <div class="form-group">
-      <label class="col-md-4 control-label">{{Mot de passe compte Somfy}}
-        <sup><i class="fas fa-question-circle tooltips" title="{{Utilisateur Somfy }}"></i></sup>
+      <label class="col-md-4 control-label">{{Mot de passe du compte Somfy}}
       </label>
       <div class="col-md-4">
         <input type="password" class="configKey form-control" data-l1key="password"/>
@@ -43,7 +41,7 @@ if (!isConnect()) {
     </div>
     <div class="form-group">
       <label class="col-md-4 control-label">{{Token Application Somfy}}
-        <sup><i class="fas fa-question-circle tooltips" title="{{Token Somfy }}"></i></sup>
+        <sup><i class="fas fa-question-circle tooltips" title="{{Accessible depuis l'application Somfy}}"></i></sup>
       </label>
       <div class="col-md-4">
         <input class="configKey form-control" data-l1key="tahomalocalapi_token"/>
@@ -51,15 +49,14 @@ if (!isConnect()) {
     </div>
     <div class="form-group">
       <label class="col-md-4 control-label">{{Code pin box Somfy}}
-        <sup><i class="fas fa-question-circle tooltips" title="{{Code pin box Somfy accessible depuis le compte client }}"></i></sup>
+        <sup><i class="fas fa-question-circle tooltips" title="{{Accessible depuis le compte client}}"></i></sup>
       </label>
       <div class="col-md-4">
         <input class="configKey form-control" data-l1key="pincode"/>
       </div>
     </div>
     <div class="form-group">
-      <label class="col-md-4 control-label">{{Adresse IP locale de la box Somfy}}
-        <sup><i class="fas fa-question-circle tooltips" title="{{Adresse IP locale de la box Somfy}}"></i></sup>
+      <label class="col-md-4 control-label">{{Adresse IP locale box Somfy}}
       </label>
       <div class="col-md-4">
         <input class="configKey form-control" data-l1key="boxLocalIp"/>

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -66,7 +66,6 @@ if (!isConnect()) {
    	<legend><i class="fas fa-list-alt"></i> {{Configuration daemon}}</legend>
     <div class="form-group">
       <label class="col-md-4 control-label">{{Port du daemon}}
-        <sup><i class="fas fa-question-circle tooltips" title="{{Port du daemon}}"></i></sup>
       </label>
       <div class="col-md-4">
         <input class="configKey form-control" data-l1key="socketport" placeholder="55009 par défaut"/>

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -58,7 +58,7 @@ if (!isConnect()) {
       </div>
     </div>
     <div class="form-group">
-      <label class="col-md-4 control-label">{{Adresse IP local de la box Somfy}}
+      <label class="col-md-4 control-label">{{Adresse IP locale de la box Somfy}}
         <sup><i class="fas fa-question-circle tooltips" title="{{Adresse IP locale de la box Somfy}}"></i></sup>
       </label>
       <div class="col-md-4">


### PR DESCRIPTION
Correctif sur mon PR précédent pour permettre la gestion à la fois du mode token (prioritaire) et du mode id / mdp
J'ai également revue les messages dans la page configuration en fonction des non réponses pour guider l'utilisateur.